### PR TITLE
Make getBarBounds callable from Objective-C code (Fixes #570)

### DIFF
--- a/Charts/Classes/Charts/BarChartView.swift
+++ b/Charts/Classes/Charts/BarChartView.swift
@@ -73,13 +73,13 @@ public class BarChartView: BarLineChartViewBase, BarChartDataProvider
     }
         
     /// - returns: the bounding box of the specified Entry in the specified DataSet. Returns null if the Entry could not be found in the charts data.
-    public func getBarBounds(e: BarChartDataEntry) -> CGRect!
+    public func getBarBounds(e: BarChartDataEntry) -> CGRect
     {
         let set = _data.getDataSetForEntry(e) as! BarChartDataSet!
         
         if (set === nil)
         {
-            return nil
+            return CGRectNull
         }
         
         let barspace = set.barSpace

--- a/Charts/Classes/Charts/HorizontalBarChartView.swift
+++ b/Charts/Classes/Charts/HorizontalBarChartView.swift
@@ -138,13 +138,13 @@ public class HorizontalBarChartView: BarChartView
         }
     }
     
-    public override func getBarBounds(e: BarChartDataEntry) -> CGRect!
+    public override func getBarBounds(e: BarChartDataEntry) -> CGRect
     {
         let set = _data.getDataSetForEntry(e) as! BarChartDataSet!
         
         if (set === nil)
         {
-            return nil
+            return CGRectNull
         }
         
         let barspace = set.barSpace


### PR DESCRIPTION
Changed method return value to nonnull, because CGRect in Objective-C doesn't allow nil since it's not an object. When the bar bounds cannot be calculated because the data set is nil now the method returns CGRectNull instead of nil.